### PR TITLE
WL-3027 Don't return contents in search results.

### DIFF
--- a/solr/impl/src/main/resources/org/sakaiproject/search/solr/conf/search/conf/solrconfig.xml
+++ b/solr/impl/src/main/resources/org/sakaiproject/search/solr/conf/search/conf/solrconfig.xml
@@ -57,7 +57,8 @@
             <str name="q.alt">*:*</str>
             <str name="q.op">AND</str>
             <int name="rows">10</int>
-            <str name="fl">*,score</str>
+            <!-- We don't want the contents in the response as it can be big -->
+            <str name="fl">indexdate,reference,container,id,type,subtype,title,tool,url,siteid, score</str>
 
             <str name="tv">true</str>
             <str name="tv.fl">contents</str>


### PR DESCRIPTION
In one example the contents was taking up 50+MB.

This isn't a full fix as we still have the termvectors, but it's a deployable start.
