### PR TITLE
WL-3027 Drop old search from the build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,7 @@
             <modules>
                 <module>search-api/api</module>
                 <module>search-help</module>
-                <module>search-impl/impl</module>
-                <module>search-impl/pack</module>
                 <module>search-integration-test</module>
-                <module>search-model</module>
                 <module>search-util</module>
                 <module>search-tool/tool</module>
                 <module>search-test</module>
@@ -46,10 +43,7 @@
             <modules>
                 <module>search-api/api</module>
                 <module>search-help</module>
-                <module>search-impl/impl</module>
-                <module>search-impl/pack</module>
                 <module>search-integration-test</module>
-                <module>search-model</module>
                 <module>search-util</module>
                 <module>search-tool/tool</module>
                 <module>search-test</module>

--- a/search-assembly/pom.xml
+++ b/search-assembly/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.search</groupId>
-            <artifactId>search-model</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.sakaiproject.search</groupId>
             <artifactId>search-help</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -45,13 +39,6 @@
             <groupId>org.sakaiproject.search.solr</groupId>
             <artifactId>solr-pack</artifactId>
             <version>${solr-pack.version}</version>
-            <scope>compile</scope>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.sakaiproject.search</groupId>
-            <artifactId>search-pack</artifactId>
-            <version>${project.version}</version>
             <scope>compile</scope>
             <type>war</type>
         </dependency>

--- a/search-assembly/src/main/assembly/deploy.xml
+++ b/search-assembly/src/main/assembly/deploy.xml
@@ -14,18 +14,8 @@
             <useTransitiveDependencies>false</useTransitiveDependencies>
             <includes>
                 <include>org.sakaiproject.search:search-api:jar:*</include>
-                <include>org.sakaiproject.search:search-model:jar:*</include>
                 <include>org.sakaiproject.search:search-help:jar:*</include>
             </includes>
-        </dependencySet>
-        <!-- stuff that goes into components -->
-        <dependencySet>
-            <outputDirectory>components/search-pack</outputDirectory>
-            <useTransitiveDependencies>false</useTransitiveDependencies>
-            <includes>
-                <include>org.sakaiproject.search:search-pack:war:*</include>
-            </includes>
-            <unpack>true</unpack>
         </dependencySet>
         <dependencySet>
             <outputDirectory>components/solr-pack</outputDirectory>


### PR DESCRIPTION
Having both copies of search in the build resulted in too many EntityContentProducers getting registered and it not being predictable which one would get used. As we have duplicates of the 2 in search-impl in solr-impl we can remove it all from our build. It wasn't consistent which ECP got found so indexing would produce unpredictable results. Ideally all the ECPs should be in search-adaptors but that's for when we do a larger refactor.
