### PR TITLE
WL-3074 When doing a full re-index nothing was looked at.

### DIFF
--- a/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentHostingContentProducer.java
+++ b/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentHostingContentProducer.java
@@ -131,7 +131,7 @@ public abstract class ContentHostingContentProducer implements EntityContentProd
         Collection<String> contentReferences = new ArrayList<String>(siteContent.size());
         for (ContentResource contentResource : siteContent) {
             String reference = contentResource.getReference();
-            if (isResourceTypeSupported(reference))
+            if (isResourceTypeSupported(contentResource.getResourceType()))
                 contentReferences.add(reference);
         }
         return contentReferences.iterator();


### PR DESCRIPTION
The content producer wasn't getting called when doing a full re-index as it was checking the reference against the list of accepted types. Example of the problem of using Strings everywhere, enums help prevent problems like this.
