### PR TITLE
WL-3356 Don’t leak memory when indexing PDFs.

### DIFF
--- a/solr/impl/pom.xml
+++ b/solr/impl/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/solr/impl/src/main/java/org/sakaiproject/search/producer/BinaryContentHostingContentProducer.java
+++ b/solr/impl/src/main/java/org/sakaiproject/search/producer/BinaryContentHostingContentProducer.java
@@ -1,5 +1,6 @@
 package org.sakaiproject.search.producer;
 
+import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.tika.Tika;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.search.api.StoredDigestContentProducer;
@@ -67,6 +68,11 @@ public class BinaryContentHostingContentProducer extends ContentHostingContentPr
             } catch (IOException e) {
                 logger.error("Error while closing the contentStream", e);
             }
+            // PDFont leaks memory so clear it out each time around.
+            // On a long running JVM the static internal HashMap
+            // (org.apache.pdfbox.pdmodel.font.PDFont.cmapObjects) has been seen
+            // to be eating up 750MB of heap.
+            PDFont.clearResources();
         }
     }
 

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -83,7 +83,7 @@
         <amqp.version>3.1.1</amqp.version>
         <hamcrest.version>1.3</hamcrest.version>
         <joda-time.version>2.2</joda-time.version>
-        <pdfbox.version>1.8.2</pdfbox.version>
+        <pdfbox.version>1.8.6</pdfbox.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
PDFBox keeps a cache of something todo with fonts and over time this just accumulates heap. To work around this we clear out the cache after indexing each document. I’ve also bumped up the version of PDFBox to the latest version.
