### PR TITLE
WL-3424 Don’t warn about not indexing directories.

### DIFF
--- a/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentProducerFactory.java
+++ b/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentProducerFactory.java
@@ -71,7 +71,7 @@ public class ContentProducerFactory {
                 logger.info("The content producer '{}' has thrown an exception", contentProducer, e);
             }
         }
-        logger.warn("Couldn't find a content producer for event '{}'", event);
+        logger.debug("Couldn't find a content producer for event '{}'", event);
         return null;
     }
 


### PR DESCRIPTION
If it’s an event that we don’t do any indexing for we don’t need to warn about this.
