### PR TITLE
WL-749 Extract the filename and include as prop.

### DIFF
--- a/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentHostingContentProducer.java
+++ b/solr/impl/src/main/java/org/sakaiproject/search/producer/ContentHostingContentProducer.java
@@ -7,6 +7,7 @@ import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.SakaiException;
 import org.sakaiproject.search.api.EntityContentProducer;
 import org.sakaiproject.search.api.SearchIndexBuilder;
 import org.sakaiproject.search.api.SearchService;
@@ -193,10 +194,38 @@ public abstract class ContentHostingContentProducer implements EntityContentProd
                 String propertyName = propertiesIterator.next();
                 props.put(propertyName, rp.getPropertyList(propertyName));
             }
+            // We want a good filename which doesn't include the path.
+            String filename = getFileName(ref);
+            if (filename != null) {
+                props.put("filename", Collections.singletonList(filename));
+            }
             return props;
         } catch (Exception e) {
             return Collections.emptyMap();
         }
+    }
+
+    /**
+     * This just extracts a filename
+     * @param ref
+     * @return
+     */
+    String getFileName(String ref) {
+        // This attempts to get the filename from a reference.
+        int start = ref.lastIndexOf("/");
+        int end = ref.length();
+
+        if (start == ref.length() - 1) {
+            // Don't include the last "/"
+            end--;
+            start = ref.lastIndexOf("/", start -1);
+        }
+        if (start > 0) {
+            return ref.substring(start + 1, end);
+        } else {
+            return null;
+        }
+
     }
 
     @Override

--- a/solr/impl/src/test/java/org/sakaiproject/search/producer/ContentHostingContentProducerTest.java
+++ b/solr/impl/src/test/java/org/sakaiproject/search/producer/ContentHostingContentProducerTest.java
@@ -1,0 +1,22 @@
+package org.sakaiproject.search.producer;
+
+import org.junit.Test;
+
+import java.io.Reader;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by buckett on 13/11/2014.
+ */
+public class ContentHostingContentProducerTest {
+
+    @Test
+    public void extractFilename() {
+        ContentHostingContentProducer cp = new BinaryContentHostingContentProducer();
+        assertEquals("file.txt", cp.getFileName("/group/content/file.txt"));
+        assertEquals("directory", cp.getFileName("/group/content/directory/"));
+        assertEquals("directory", cp.getFileName("/group/content/directory"));
+        assertEquals(null, cp.getFileName("file"));
+    }
+}


### PR DESCRIPTION
The solr config will look for a field of property_filename and if it exists copy it into the filename field. We don’t put it directly into the filename field as the properties are the only way to pass additional data to the index.

The solr config will also include the filename field in all searches.
