### PR TITLE
WL-3612 Don’t every return null as it NPEs.

### DIFF
--- a/solr/impl/src/main/java/org/sakaiproject/search/solr/SolrSearchService.java
+++ b/solr/impl/src/main/java/org/sakaiproject/search/solr/SolrSearchService.java
@@ -293,7 +293,7 @@ public class SolrSearchService implements SearchService {
             QueryResponse response = solrServer.query(params);
             SpellCheckResponse spellCheckResponse = response.getSpellCheckResponse();
             if (spellCheckResponse == null || !spellCheckResponse.isCorrectlySpelled())
-                return null;
+                return new String[]{};
             else {
                 List<SpellCheckResponse.Collation> collatedResults = spellCheckResponse.getCollatedResults();
                 List<String> suggestions = new ArrayList<String>(collatedResults.size());


### PR DESCRIPTION
The solr implementation of search was returning a null for suggestions which was causing the search tool to NPE. Now we just return an empty array.
